### PR TITLE
feat: add rep max (RM) resolution for percentage-based weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ C. Back Squat: 4 x 6 @ 80% 1RM, rest 2 min
 
 After (in Notion):
 ```
-C. Back Squat: 4 x 6 @ 252 lbs, rest 2 min
+C. Back Squat: 4 x 6 @ 80% 1RM (252 lbs), rest 2 min
 ```
 
 The resolver:
 1. Extracts the exercise name from the section header ("Back Squat")
 2. Matches it against your `repMaxes` config (finds "squat" with aliases)
 3. Calculates 80% of 315 lbs = 252 lbs
-4. Replaces the percentage reference with the calculated weight
+4. Appends the calculated weight in parentheses (preserving the original percentage)
 
 ### Matching Logic
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,59 @@ Squats: 3 sets of 15
 Lunges: 3 sets of 10 each leg
 ```
 
+## Rep Max (RM) Resolution
+
+The CLI can automatically resolve percentage-based weight references to actual weights based on your stored rep maxes.
+
+### Configuration
+
+Add a `repMaxes` array to your `config.json`:
+
+```json
+{
+  "repMaxes": [
+    { "exercise": "squat", "weight": 315, "aliases": ["back squat", "barbell squat"] },
+    { "exercise": "bench press", "weight": 225, "aliases": ["bench"] },
+    { "exercise": "deadlift", "weight": 405 }
+  ],
+  "defaultUnit": "lbs"
+}
+```
+
+### Supported Patterns
+
+The resolver recognizes these percentage patterns:
+
+- `@75% 1RM` / `@75%1RM` / `@ 75% 1RM` - Uses exercise from section context
+- `@80% squat` / `@75% bench press` - Explicit exercise name
+- `75% of 1RM` - Uses exercise from section context
+- `80% of squat` - Explicit exercise name
+
+### Example
+
+Before (in Google Sheets):
+```
+C. Back Squat: 4 x 6 @ 80% 1RM, rest 2 min
+```
+
+After (in Notion):
+```
+C. Back Squat: 4 x 6 @ 252 lbs, rest 2 min
+```
+
+The resolver:
+1. Extracts the exercise name from the section header ("Back Squat")
+2. Matches it against your `repMaxes` config (finds "squat" with aliases)
+3. Calculates 80% of 315 lbs = 252 lbs
+4. Replaces the percentage reference with the calculated weight
+
+### Matching Logic
+
+- Exact matches are preferred over partial matches
+- Longer matches are preferred (e.g., "clean grip rdl" > "rdl" > "dl")
+- Aliases are checked alongside canonical exercise names
+- If no match is found, the original text is preserved
+
 ## Files
 
 - `wgs` - CLI entry point (run from repo root)
@@ -95,5 +148,6 @@ Lunges: 3 sets of 10 each leg
 - `src/sheets.ts` - Google Sheets API client
 - `src/notion.ts` - Notion API client and page creation
 - `src/parser.ts` - Workout data parser with section detection
+- `src/rm-resolver.ts` - Rep max percentage resolution
 - `config.json` - Notion configuration (create from example)
 - `credentials.json` - Google API credentials (create from example)

--- a/config.example.json
+++ b/config.example.json
@@ -7,5 +7,11 @@
     "sheetOwner": "your-email@gmail.com",
     "sheetTitle": "Your Workout Sheet",
     "cellRange": "B2:E5"
-  }
+  },
+  "repMaxes": [
+    { "exercise": "squat", "weight": 315, "aliases": ["back squat", "barbell squat"] },
+    { "exercise": "bench press", "weight": 225, "aliases": ["bench", "barbell bench"] },
+    { "exercise": "deadlift", "weight": 405, "aliases": ["conventional deadlift", "dl"] }
+  ],
+  "defaultUnit": "lbs"
 }

--- a/src/commands/create-day.ts
+++ b/src/commands/create-day.ts
@@ -81,7 +81,10 @@ export async function runCreateDay(options: CreateDayOptions): Promise<void> {
     const cellContent = data[0][0];
 
     console.log('Parsing workout data...');
-    const session = WorkoutParser.parseSingleCell(cellContent);
+    let session = WorkoutParser.parseSingleCell(cellContent);
+    
+    // Resolve RM (rep max) references to actual weights
+    session = await WorkoutParser.resolveRepMaxes(session);
 
     console.log(`Found workout session with ${session.sections.length} sections`);
 

--- a/src/commands/create-week.ts
+++ b/src/commands/create-week.ts
@@ -92,7 +92,12 @@ export async function runCreateWeek(options: CreateWeekOptions): Promise<void> {
     const data = await sheetsClient.getCellRange(sheetInfo.id, cellRange);
 
     console.log('Parsing workout data...');
-    const sessions = WorkoutParser.parseWorkoutData(data);
+    let sessions = WorkoutParser.parseWorkoutData(data);
+    
+    // Resolve RM (rep max) references to actual weights for each session
+    sessions = await Promise.all(
+      sessions.map(session => WorkoutParser.resolveRepMaxes(session))
+    );
 
     console.log(`Found ${sessions.length} workout sessions:`);
     sessions.forEach((session) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,5 @@
-import type { WorkoutSession } from './notion';
+import type { WorkoutSession, WorkoutSectionData } from './notion';
+import { RMResolver, loadRMConfig } from './rm-resolver';
 
 export class WorkoutParser {
   private static readonly SECTION_HEADER_PATTERN = /^[A-Z]\d*\./;
@@ -151,5 +152,53 @@ export class WorkoutParser {
   static generatePageTitle(ownerEmail: string, sheetTitle: string): string {
     const date = new Date().toISOString().split('T')[0];
     return `${sheetTitle} - ${date}`;
+  }
+
+  /**
+   * Resolve RM (rep max) references in a parsed workout session.
+   * Replaces percentage-based references with actual weights based on config.
+   * 
+   * @param session - The parsed workout session
+   * @param configPath - Path to config file (default: 'config.json')
+   * @returns Session with RM references resolved to weights
+   */
+  static async resolveRepMaxes(session: WorkoutSession, configPath: string = 'config.json'): Promise<WorkoutSession> {
+    const rmConfig = await loadRMConfig(configPath);
+    
+    if (!rmConfig) {
+      // No RM config found, return session unchanged
+      return session;
+    }
+    
+    const resolver = new RMResolver(rmConfig);
+    
+    // Deep clone the session to avoid mutating the original
+    const resolvedSession: WorkoutSession = {
+      sessionNumber: session.sessionNumber,
+      sections: session.sections.map(section => ({
+        ...section,
+        header: section.header,
+        content: [...section.content],
+        youtubeLinks: [...section.youtubeLinks],
+      })),
+    };
+    
+    // Process each section
+    for (const section of resolvedSession.sections) {
+      // Use header as context for RM resolution (contains exercise name)
+      const contextLine = section.header || '';
+      
+      // Resolve RM references in the header
+      if (section.header) {
+        section.header = resolver.resolveLine(section.header, contextLine);
+      }
+      
+      // Resolve RM references in content lines
+      section.content = section.content.map(line => 
+        resolver.resolveLine(line, contextLine)
+      );
+    }
+    
+    return resolvedSession;
   }
 }

--- a/src/rm-resolver.ts
+++ b/src/rm-resolver.ts
@@ -121,7 +121,7 @@ export class RMResolver {
       const oneRM = this.findRepMax(undefined, contextLine);
       if (oneRM !== null) {
         const weight = this.calculateWeight(percentage, oneRM);
-        return `@ ${weight} ${this.defaultUnit}`;
+        return `${match} (${weight} ${this.defaultUnit})`;
       }
       return match; // Keep original if no match found
     });
@@ -132,7 +132,7 @@ export class RMResolver {
       const oneRM = this.findRepMax(exercise.trim());
       if (oneRM !== null) {
         const weight = this.calculateWeight(percentage, oneRM);
-        return `@ ${weight} ${this.defaultUnit}`;
+        return `${match} (${weight} ${this.defaultUnit})`;
       }
       return match;
     });
@@ -143,7 +143,7 @@ export class RMResolver {
       const oneRM = this.findRepMax(undefined, contextLine);
       if (oneRM !== null) {
         const weight = this.calculateWeight(percentage, oneRM);
-        return `${weight} ${this.defaultUnit}`;
+        return `${match} (${weight} ${this.defaultUnit})`;
       }
       return match;
     });
@@ -154,7 +154,7 @@ export class RMResolver {
       const oneRM = this.findRepMax(exercise.trim());
       if (oneRM !== null) {
         const weight = this.calculateWeight(percentage, oneRM);
-        return `${weight} ${this.defaultUnit}`;
+        return `${match} (${weight} ${this.defaultUnit})`;
       }
       return match;
     });

--- a/src/rm-resolver.ts
+++ b/src/rm-resolver.ts
@@ -1,0 +1,194 @@
+/**
+ * RM (Rep Max) Resolver
+ * 
+ * Resolves percentage-based weight references in workout content to actual weights.
+ * 
+ * Patterns supported:
+ * - "@75% 1RM" / "@75%1RM" / "@ 75% 1RM"
+ * - "@75% <exercise>" (e.g., "@75% squat", "@80% bench")
+ * - "75% of 1RM"
+ * - Handles both with and without spaces
+ */
+
+export interface RepMax {
+  exercise: string;      // Canonical exercise name (e.g., "squat", "bench press")
+  weight: number;        // Weight in lbs
+  aliases?: string[];    // Alternative names that match this exercise
+}
+
+export interface RMConfig {
+  repMaxes: RepMax[];
+  defaultUnit?: 'lbs' | 'kg';
+}
+
+// Pattern to match percentage references
+// Captures: percentage, optional exercise name
+const RM_PATTERNS = [
+  // "@75% 1RM" or "@75%1RM" or "@ 75% 1RM"
+  /@\s*(\d+(?:\.\d+)?)\s*%\s*1?\s*RM\b/gi,
+  // "@75% squat" or "@80% bench press"
+  /@\s*(\d+(?:\.\d+)?)\s*%\s+(\w[\w\s]*?)(?=,|\.|;|$|\s+@|\s+rest|\s+x\s*\d)/gi,
+  // "75% of 1RM"
+  /(\d+(?:\.\d+)?)\s*%\s+of\s+1?\s*RM\b/gi,
+  // "75% of squat"
+  /(\d+(?:\.\d+)?)\s*%\s+of\s+(\w[\w\s]*?)(?=,|\.|;|$|\s+@|\s+rest|\s+x\s*\d)/gi,
+];
+
+export class RMResolver {
+  private repMaxes: Map<string, number> = new Map();
+  private defaultUnit: 'lbs' | 'kg';
+
+  constructor(config: RMConfig) {
+    this.defaultUnit = config.defaultUnit || 'lbs';
+    
+    for (const rm of config.repMaxes) {
+      // Store canonical name (lowercase)
+      this.repMaxes.set(rm.exercise.toLowerCase(), rm.weight);
+      
+      // Store aliases
+      if (rm.aliases) {
+        for (const alias of rm.aliases) {
+          this.repMaxes.set(alias.toLowerCase(), rm.weight);
+        }
+      }
+    }
+  }
+
+  /**
+   * Find the best matching rep max for an exercise name from context.
+   * Prioritizes exact matches, then longest partial matches.
+   */
+  private findRepMax(exerciseName?: string, contextLine?: string): number | null {
+    // If explicit exercise name provided, try to match it
+    if (exerciseName) {
+      const normalized = exerciseName.toLowerCase().trim();
+      if (this.repMaxes.has(normalized)) {
+        return this.repMaxes.get(normalized)!;
+      }
+      
+      // Try partial matching - prefer longest match
+      let bestMatch: { key: string; weight: number } | null = null;
+      for (const [key, weight] of this.repMaxes) {
+        if (normalized.includes(key) || key.includes(normalized)) {
+          if (!bestMatch || key.length > bestMatch.key.length) {
+            bestMatch = { key, weight };
+          }
+        }
+      }
+      if (bestMatch) {
+        return bestMatch.weight;
+      }
+    }
+    
+    // Try to infer from context line (e.g., section header)
+    if (contextLine) {
+      const lineLower = contextLine.toLowerCase();
+      
+      // Find the longest matching key (most specific match)
+      let bestMatch: { key: string; weight: number } | null = null;
+      for (const [key, weight] of this.repMaxes) {
+        if (lineLower.includes(key)) {
+          if (!bestMatch || key.length > bestMatch.key.length) {
+            bestMatch = { key, weight };
+          }
+        }
+      }
+      if (bestMatch) {
+        return bestMatch.weight;
+      }
+    }
+    
+    return null;
+  }
+
+  /**
+   * Calculate weight from percentage and 1RM
+   */
+  private calculateWeight(percentage: number, oneRM: number): number {
+    return Math.round((percentage / 100) * oneRM);
+  }
+
+  /**
+   * Resolve a single line of workout content
+   * Returns the line with RM references replaced with actual weights
+   */
+  resolveLine(line: string, contextLine?: string): string {
+    let result = line;
+    
+    // Pattern 1: @75% 1RM (generic, needs context)
+    result = result.replace(/@\s*(\d+(?:\.\d+)?)\s*%\s*1?\s*RM\b/gi, (match, pct) => {
+      const percentage = parseFloat(pct);
+      const oneRM = this.findRepMax(undefined, contextLine);
+      if (oneRM !== null) {
+        const weight = this.calculateWeight(percentage, oneRM);
+        return `@ ${weight} ${this.defaultUnit}`;
+      }
+      return match; // Keep original if no match found
+    });
+    
+    // Pattern 2: @75% squat (explicit exercise)
+    result = result.replace(/@\s*(\d+(?:\.\d+)?)\s*%\s+(\w[\w\s]*?)(?=,|\.|;|$|\s+@|\s+rest|\s+x\s*\d|\))/gi, (match, pct, exercise) => {
+      const percentage = parseFloat(pct);
+      const oneRM = this.findRepMax(exercise.trim());
+      if (oneRM !== null) {
+        const weight = this.calculateWeight(percentage, oneRM);
+        return `@ ${weight} ${this.defaultUnit}`;
+      }
+      return match;
+    });
+    
+    // Pattern 3: 75% of 1RM
+    result = result.replace(/(\d+(?:\.\d+)?)\s*%\s+of\s+1?\s*RM\b/gi, (match, pct) => {
+      const percentage = parseFloat(pct);
+      const oneRM = this.findRepMax(undefined, contextLine);
+      if (oneRM !== null) {
+        const weight = this.calculateWeight(percentage, oneRM);
+        return `${weight} ${this.defaultUnit}`;
+      }
+      return match;
+    });
+    
+    // Pattern 4: 75% of squat
+    result = result.replace(/(\d+(?:\.\d+)?)\s*%\s+of\s+(\w[\w\s]*?)(?=,|\.|;|$|\s+@|\s+rest|\s+x\s*\d)/gi, (match, pct, exercise) => {
+      const percentage = parseFloat(pct);
+      const oneRM = this.findRepMax(exercise.trim());
+      if (oneRM !== null) {
+        const weight = this.calculateWeight(percentage, oneRM);
+        return `${weight} ${this.defaultUnit}`;
+      }
+      return match;
+    });
+    
+    return result;
+  }
+
+  /**
+   * Check if a line contains any RM references
+   */
+  hasRMReference(line: string): boolean {
+    return /@\s*\d+(?:\.\d+)?\s*%/i.test(line) || 
+           /\d+(?:\.\d+)?\s*%\s+of\s+/i.test(line);
+  }
+}
+
+/**
+ * Load RM config from the main config file
+ */
+export async function loadRMConfig(configPath: string = 'config.json'): Promise<RMConfig | null> {
+  try {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile(configPath, 'utf8');
+    const config = JSON.parse(content);
+    
+    if (config.repMaxes && Array.isArray(config.repMaxes)) {
+      return {
+        repMaxes: config.repMaxes,
+        defaultUnit: config.defaultUnit || 'lbs',
+      };
+    }
+    
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/test/rm-resolver.test.ts
+++ b/test/rm-resolver.test.ts
@@ -18,58 +18,58 @@ describe('RMResolver', () => {
   describe('basic percentage patterns', () => {
     test('resolves @75% 1RM with context', () => {
       const result = resolver.resolveLine('4 x 6 reps @ 75% 1RM', 'C. Back Squat: 4 x 6 reps');
-      expect(result).toBe('4 x 6 reps @ 236 lbs');
+      expect(result).toBe('4 x 6 reps @ 75% 1RM (236 lbs)');
     });
 
     test('resolves @80%1RM without space', () => {
       const result = resolver.resolveLine('3 x 5 @80%1RM', 'A. Bench Press');
-      expect(result).toBe('3 x 5 @ 180 lbs');
+      expect(result).toBe('3 x 5 @80%1RM (180 lbs)');
     });
 
     test('resolves @ 85% RM with spaces', () => {
       const result = resolver.resolveLine('5 x 3 @ 85% RM, rest 3 min', 'B. Deadlift');
-      expect(result).toBe('5 x 3 @ 344 lbs, rest 3 min');
+      expect(result).toBe('5 x 3 @ 85% RM (344 lbs), rest 3 min');
     });
   });
 
   describe('explicit exercise patterns', () => {
     test('resolves @75% squat', () => {
       const result = resolver.resolveLine('4 x 6 @ 75% squat, rest 2 min');
-      expect(result).toBe('4 x 6 @ 236 lbs, rest 2 min');
+      expect(result).toBe('4 x 6 @ 75% squat (236 lbs), rest 2 min');
     });
 
     test('resolves @80% bench press', () => {
       const result = resolver.resolveLine('3 x 5 @ 80% bench press');
-      expect(result).toBe('3 x 5 @ 180 lbs');
+      expect(result).toBe('3 x 5 @ 80% bench press (180 lbs)');
     });
 
     test('resolves @90% deadlift', () => {
       const result = resolver.resolveLine('1 x 1 @ 90% deadlift');
-      expect(result).toBe('1 x 1 @ 365 lbs');
+      expect(result).toBe('1 x 1 @ 90% deadlift (365 lbs)');
     });
   });
 
   describe('of 1RM patterns', () => {
     test('resolves 75% of 1RM with context', () => {
       const result = resolver.resolveLine('Use 75% of 1RM', 'Clean Grip RDL');
-      expect(result).toBe('Use 169 lbs');
+      expect(result).toBe('Use 75% of 1RM (169 lbs)');
     });
 
     test('resolves 80% of squat', () => {
       const result = resolver.resolveLine('Work up to 80% of squat');
-      expect(result).toBe('Work up to 252 lbs');
+      expect(result).toBe('Work up to 80% of squat (252 lbs)');
     });
   });
 
   describe('alias matching', () => {
     test('matches exercise alias', () => {
       const result = resolver.resolveLine('5 x 5 @ 70% 1RM', 'A. Back Squat');
-      expect(result).toBe('5 x 5 @ 221 lbs');
+      expect(result).toBe('5 x 5 @ 70% 1RM (221 lbs)');
     });
 
     test('matches dl alias', () => {
       const result = resolver.resolveLine('3 x 3 @ 85% dl');
-      expect(result).toBe('3 x 3 @ 344 lbs');
+      expect(result).toBe('3 x 3 @ 85% dl (344 lbs)');
     });
   });
 
@@ -103,7 +103,7 @@ describe('RMResolver', () => {
     test('rounds to nearest whole number', () => {
       // 315 * 0.73 = 229.95, should round to 230
       const result = resolver.resolveLine('@ 73% squat');
-      expect(result).toBe('@ 230 lbs');
+      expect(result).toBe('@ 73% squat (230 lbs)');
     });
   });
 });

--- a/test/rm-resolver.test.ts
+++ b/test/rm-resolver.test.ts
@@ -1,0 +1,109 @@
+import { test, expect, describe } from 'bun:test';
+import { RMResolver, RMConfig } from '../src/rm-resolver';
+
+describe('RMResolver', () => {
+  const testConfig: RMConfig = {
+    repMaxes: [
+      { exercise: 'squat', weight: 315, aliases: ['back squat', 'barbell squat'] },
+      { exercise: 'bench press', weight: 225, aliases: ['bench', 'barbell bench'] },
+      { exercise: 'deadlift', weight: 405, aliases: ['conventional deadlift', 'dl'] },
+      { exercise: 'rdl', weight: 275, aliases: ['romanian deadlift'] },
+      { exercise: 'clean grip rdl', weight: 225 },
+    ],
+    defaultUnit: 'lbs',
+  };
+
+  const resolver = new RMResolver(testConfig);
+
+  describe('basic percentage patterns', () => {
+    test('resolves @75% 1RM with context', () => {
+      const result = resolver.resolveLine('4 x 6 reps @ 75% 1RM', 'C. Back Squat: 4 x 6 reps');
+      expect(result).toBe('4 x 6 reps @ 236 lbs');
+    });
+
+    test('resolves @80%1RM without space', () => {
+      const result = resolver.resolveLine('3 x 5 @80%1RM', 'A. Bench Press');
+      expect(result).toBe('3 x 5 @ 180 lbs');
+    });
+
+    test('resolves @ 85% RM with spaces', () => {
+      const result = resolver.resolveLine('5 x 3 @ 85% RM, rest 3 min', 'B. Deadlift');
+      expect(result).toBe('5 x 3 @ 344 lbs, rest 3 min');
+    });
+  });
+
+  describe('explicit exercise patterns', () => {
+    test('resolves @75% squat', () => {
+      const result = resolver.resolveLine('4 x 6 @ 75% squat, rest 2 min');
+      expect(result).toBe('4 x 6 @ 236 lbs, rest 2 min');
+    });
+
+    test('resolves @80% bench press', () => {
+      const result = resolver.resolveLine('3 x 5 @ 80% bench press');
+      expect(result).toBe('3 x 5 @ 180 lbs');
+    });
+
+    test('resolves @90% deadlift', () => {
+      const result = resolver.resolveLine('1 x 1 @ 90% deadlift');
+      expect(result).toBe('1 x 1 @ 365 lbs');
+    });
+  });
+
+  describe('of 1RM patterns', () => {
+    test('resolves 75% of 1RM with context', () => {
+      const result = resolver.resolveLine('Use 75% of 1RM', 'Clean Grip RDL');
+      expect(result).toBe('Use 169 lbs');
+    });
+
+    test('resolves 80% of squat', () => {
+      const result = resolver.resolveLine('Work up to 80% of squat');
+      expect(result).toBe('Work up to 252 lbs');
+    });
+  });
+
+  describe('alias matching', () => {
+    test('matches exercise alias', () => {
+      const result = resolver.resolveLine('5 x 5 @ 70% 1RM', 'A. Back Squat');
+      expect(result).toBe('5 x 5 @ 221 lbs');
+    });
+
+    test('matches dl alias', () => {
+      const result = resolver.resolveLine('3 x 3 @ 85% dl');
+      expect(result).toBe('3 x 3 @ 344 lbs');
+    });
+  });
+
+  describe('no match scenarios', () => {
+    test('preserves original when no RM config matches', () => {
+      const result = resolver.resolveLine('4 x 6 @ 75% 1RM', 'A. Overhead Press');
+      expect(result).toBe('4 x 6 @ 75% 1RM');
+    });
+
+    test('preserves original when no percentage pattern', () => {
+      const result = resolver.resolveLine('4 x 6 @ 185 lbs', 'A. Squat');
+      expect(result).toBe('4 x 6 @ 185 lbs');
+    });
+  });
+
+  describe('hasRMReference', () => {
+    test('detects @75% pattern', () => {
+      expect(resolver.hasRMReference('4 x 6 @ 75% 1RM')).toBe(true);
+    });
+
+    test('detects percentage of pattern', () => {
+      expect(resolver.hasRMReference('Use 80% of 1RM')).toBe(true);
+    });
+
+    test('returns false for no RM reference', () => {
+      expect(resolver.hasRMReference('4 x 6 @ 185 lbs')).toBe(false);
+    });
+  });
+
+  describe('rounding', () => {
+    test('rounds to nearest whole number', () => {
+      // 315 * 0.73 = 229.95, should round to 230
+      const result = resolver.resolveLine('@ 73% squat');
+      expect(result).toBe('@ 230 lbs');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds automatic resolution of percentage-based weight references (like `@75% 1RM`) to actual weights based on configured rep maxes.

## Features

- **RMResolver class** - Parses and resolves RM percentage patterns
- **Multiple pattern support:**
  - `@75% 1RM` / `@75%1RM` - Uses exercise from section context
  - `@80% squat` - Explicit exercise name
  - `75% of 1RM` - Alternative syntax
  - `80% of bench press` - Alternative with explicit exercise
- **Smart matching:**
  - Exact matches preferred over partial
  - Longest substring match wins (e.g., "clean grip rdl" > "rdl" > "dl")
  - Support for exercise aliases
- **Integrated into both create-day and create-week commands**

## Configuration

Add to `config.json`:
```json
{
  "repMaxes": [
    { "exercise": "squat", "weight": 315, "aliases": ["back squat"] },
    { "exercise": "bench press", "weight": 225, "aliases": ["bench"] }
  ],
  "defaultUnit": "lbs"
}
```

## Example

**Input (Google Sheets):**
```
C. Back Squat: 4 x 6 @ 80% 1RM, rest 2 min
```

**Output (Notion):**
```
C. Back Squat: 4 x 6 @ 252 lbs, rest 2 min
```

## Testing

- Added comprehensive test suite with 16 tests covering all patterns and edge cases
- All tests pass ✅