### PR TITLE
feat(post-workout): chunk --test output for Google Sheets mobile comments

### DIFF
--- a/src/commands/post-workout-comment-format.ts
+++ b/src/commands/post-workout-comment-format.ts
@@ -1,0 +1,261 @@
+export interface WorkoutContent {
+  overallNotes: string;
+  lowerBody: string;
+  upperBody: string;
+}
+
+export interface CommentChunk {
+  label: string;
+  content: string;
+  charCount: number;
+  overSafeLimit: boolean;
+  sectionName: string;
+  sectionPart: number;
+  sectionPartCount: number;
+  chunkNumber: number;
+  chunkCount: number;
+}
+
+interface SectionChunk {
+  sectionName: string;
+  content: string;
+  sectionPart: number;
+  sectionPartCount: number;
+}
+
+interface SectionBlock {
+  text: string;
+  isMovement: boolean;
+}
+
+const MOVEMENT_HEADER_PATTERN = /^\s*(?:#{1,6}\s*)?[A-Z]\d*\.\s*/;
+const HEADING_PATTERN = /^\s*#{1,6}\s+/;
+
+export const GOOGLE_SHEETS_COMMENT_SAFE_CHARS = 500;
+
+function isMovementHeader(line: string): boolean {
+  return MOVEMENT_HEADER_PATTERN.test(line.trim());
+}
+
+function trimBlankLines(lines: string[]): string[] {
+  let start = 0;
+  let end = lines.length - 1;
+
+  while (start <= end && lines[start]?.trim() === '') {
+    start += 1;
+  }
+
+  while (end >= start && lines[end]?.trim() === '') {
+    end -= 1;
+  }
+
+  return lines.slice(start, end + 1);
+}
+
+function splitNonMovementBlockBySentence(text: string, maxChars: number): string[] {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length <= maxChars) {
+    return trimmed ? [trimmed] : [];
+  }
+
+  const sentenceMatches = trimmed.match(/[^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$/g);
+  if (!sentenceMatches || sentenceMatches.length <= 1) {
+    return [trimmed];
+  }
+
+  const sentences = sentenceMatches.map(sentence => sentence.trim()).filter(Boolean);
+  if (sentences.length <= 1) {
+    return [trimmed];
+  }
+
+  const parts: string[] = [];
+  let current = '';
+
+  for (const sentence of sentences) {
+    const candidate = current ? `${current} ${sentence}` : sentence;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      parts.push(current);
+    }
+
+    if (sentence.length <= maxChars) {
+      current = sentence;
+    } else {
+      parts.push(sentence);
+      current = '';
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts.length > 0 ? parts : [trimmed];
+}
+
+function buildSectionHeaderAndBlocks(sectionContent: string, sectionName: string): { header: string; blocks: SectionBlock[] } {
+  const trimmedSection = sectionContent.trim();
+  if (!trimmedSection) {
+    return { header: `### ${sectionName}:`, blocks: [] };
+  }
+
+  const lines = trimmedSection.split('\n');
+  const firstLine = lines[0]?.trim() ?? '';
+  const hasHeading = HEADING_PATTERN.test(firstLine);
+  const header = hasHeading ? firstLine : `### ${sectionName}:`;
+  const bodyLines = hasHeading ? lines.slice(1) : lines;
+  const blocks: SectionBlock[] = [];
+
+  let currentLines: string[] = [];
+  let currentIsMovement = false;
+
+  const pushCurrentBlock = () => {
+    const normalizedLines = trimBlankLines(currentLines);
+    const blockText = normalizedLines.join('\n').trim();
+    if (blockText) {
+      blocks.push({ text: blockText, isMovement: currentIsMovement });
+    }
+    currentLines = [];
+  };
+
+  for (const line of bodyLines) {
+    if (isMovementHeader(line)) {
+      pushCurrentBlock();
+      currentLines = [line];
+      currentIsMovement = true;
+      continue;
+    }
+
+    if (currentLines.length === 0) {
+      currentIsMovement = false;
+    }
+    currentLines.push(line);
+  }
+
+  pushCurrentBlock();
+
+  return { header, blocks };
+}
+
+function renderSectionChunk(header: string, blockTexts: string[]): string {
+  const body = blockTexts.map(text => text.trim()).filter(Boolean).join('\n\n').trim();
+  if (!header) {
+    return body;
+  }
+  if (!body) {
+    return header.trim();
+  }
+  return `${header.trim()}\n${body}`;
+}
+
+function chunkSection(sectionName: string, sectionContent: string, maxChars: number): SectionChunk[] {
+  const trimmedSection = sectionContent.trim();
+  if (!trimmedSection) {
+    return [];
+  }
+
+  if (trimmedSection.length <= maxChars) {
+    return [{
+      sectionName,
+      content: trimmedSection,
+      sectionPart: 1,
+      sectionPartCount: 1,
+    }];
+  }
+
+  const { header, blocks } = buildSectionHeaderAndBlocks(trimmedSection, sectionName);
+  if (blocks.length === 0) {
+    return [{
+      sectionName,
+      content: trimmedSection,
+      sectionPart: 1,
+      sectionPartCount: 1,
+    }];
+  }
+
+  const preparedBlocks: SectionBlock[] = [];
+
+  for (const block of blocks) {
+    if (block.isMovement) {
+      preparedBlocks.push(block);
+      continue;
+    }
+
+    const splitBlocks = splitNonMovementBlockBySentence(block.text, maxChars);
+    for (const splitBlock of splitBlocks) {
+      preparedBlocks.push({ text: splitBlock, isMovement: false });
+    }
+  }
+
+  const chunkContents: string[] = [];
+  let currentChunkBlocks: string[] = [];
+
+  for (const block of preparedBlocks) {
+    const withCandidate = renderSectionChunk(header, [...currentChunkBlocks, block.text]);
+    if (withCandidate.length <= maxChars || currentChunkBlocks.length === 0) {
+      currentChunkBlocks.push(block.text);
+
+      const singleBlockChunk = renderSectionChunk(header, currentChunkBlocks);
+      if (singleBlockChunk.length > maxChars) {
+        chunkContents.push(singleBlockChunk);
+        currentChunkBlocks = [];
+      }
+      continue;
+    }
+
+    chunkContents.push(renderSectionChunk(header, currentChunkBlocks));
+    currentChunkBlocks = [block.text];
+
+    const singleBlockChunk = renderSectionChunk(header, currentChunkBlocks);
+    if (singleBlockChunk.length > maxChars) {
+      chunkContents.push(singleBlockChunk);
+      currentChunkBlocks = [];
+    }
+  }
+
+  if (currentChunkBlocks.length > 0) {
+    chunkContents.push(renderSectionChunk(header, currentChunkBlocks));
+  }
+
+  if (chunkContents.length === 0) {
+    chunkContents.push(trimmedSection);
+  }
+
+  return chunkContents.map((content, index) => ({
+    sectionName,
+    content,
+    sectionPart: index + 1,
+    sectionPartCount: chunkContents.length,
+  }));
+}
+
+export function buildGoogleSheetsCommentChunks(
+  workoutContent: WorkoutContent,
+  maxChars: number = GOOGLE_SHEETS_COMMENT_SAFE_CHARS,
+): CommentChunk[] {
+  const sectionChunks: SectionChunk[] = [
+    ...chunkSection('Overall Notes', workoutContent.overallNotes, maxChars),
+    ...chunkSection('Lower Body', workoutContent.lowerBody, maxChars),
+    ...chunkSection('Upper Body', workoutContent.upperBody, maxChars),
+  ];
+
+  const chunkCount = sectionChunks.length;
+
+  return sectionChunks.map((chunk, index) => ({
+    label: chunk.sectionPartCount > 1
+      ? `${chunk.sectionName} (Part ${chunk.sectionPart}/${chunk.sectionPartCount})`
+      : chunk.sectionName,
+    content: chunk.content,
+    charCount: chunk.content.length,
+    overSafeLimit: chunk.content.length > maxChars,
+    sectionName: chunk.sectionName,
+    sectionPart: chunk.sectionPart,
+    sectionPartCount: chunk.sectionPartCount,
+    chunkNumber: index + 1,
+    chunkCount,
+  }));
+}

--- a/src/commands/post-workout.ts
+++ b/src/commands/post-workout.ts
@@ -4,6 +4,10 @@ import { NotionClient } from '../notion';
 import fs from 'fs/promises';
 import { Client } from '@notionhq/client';
 import { google } from 'googleapis';
+import {
+  buildGoogleSheetsCommentChunks,
+  type WorkoutContent,
+} from './post-workout-comment-format';
 
 interface Config {
   notion: {
@@ -14,12 +18,6 @@ interface Config {
     sheetOwner?: string;
     sheetTitle?: string;
   };
-}
-
-interface WorkoutContent {
-  overallNotes: string;
-  lowerBody: string;
-  upperBody: string;
 }
 
 interface PostWorkoutOptions {
@@ -367,16 +365,28 @@ export async function runPostWorkout(options: PostWorkoutOptions): Promise<void>
     const workoutContent = postWorkoutClient.splitContentByWorkoutSections(markdown);
 
     if (options.test) {
-      console.log('\n=== TEST MODE OUTPUT ===');
-      if (workoutContent.overallNotes) {
-        console.log(`\n${workoutContent.overallNotes}`);
+      const chunks = buildGoogleSheetsCommentChunks(workoutContent);
+
+      console.log('\n=== TEST MODE OUTPUT (Google Sheets Mobile Chunks) ===');
+
+      if (chunks.length === 0) {
+        console.log('\nNo workout content found.');
+        console.log('\n=== End Test Output ===');
+        return;
       }
-      if (workoutContent.lowerBody) {
-        console.log(`\n${workoutContent.lowerBody}`);
+
+      for (const chunk of chunks) {
+        const overLimitLabel = chunk.overSafeLimit
+          ? ' [Over 500 chars: single movement/sentence too long to split safely]'
+          : '';
+
+        console.log(`\n[Chunk ${chunk.chunkNumber}/${chunk.chunkCount}] ${chunk.label} (${chunk.charCount} chars)${overLimitLabel}`);
+        console.log(`Paste into ${cellId} comment.`);
+        console.log('--- START COPY ---');
+        console.log(chunk.content);
+        console.log('--- END COPY ---');
       }
-      if (workoutContent.upperBody) {
-        console.log(`\n${workoutContent.upperBody}`);
-      }
+
       console.log('\n=== End Test Output ===');
       return;
     }

--- a/test/post-workout-comment-format.test.ts
+++ b/test/post-workout-comment-format.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildGoogleSheetsCommentChunks,
+  type WorkoutContent,
+} from '../src/commands/post-workout-comment-format';
+
+describe('buildGoogleSheetsCommentChunks', () => {
+  test('splits by top-level workout sections by default', () => {
+    const workoutContent: WorkoutContent = {
+      overallNotes: '### Overall Notes:\nRecovery felt solid today.',
+      lowerBody: '### Lower Body:\nA. Back Squat\n4 x 6 @ 75% 1RM\n\nB. Reverse Lunge\n3 x 10 each side',
+      upperBody: '### Upper Body:\nA. Bench Press\n4 x 5 @ 80%\n\nB. Pull-Up\n4 x 8',
+    };
+
+    const chunks = buildGoogleSheetsCommentChunks(workoutContent, 500);
+
+    expect(chunks.length).toBe(3);
+    expect(chunks.every(chunk => chunk.charCount <= 500)).toBe(true);
+    expect(chunks.map(chunk => chunk.label)).toEqual([
+      'Overall Notes',
+      'Lower Body',
+      'Upper Body',
+    ]);
+  });
+
+  test('splits long lower-body content by movement letter without splitting movements', () => {
+    const movementA = [
+      'A. Back Squat',
+      'Build to a strong top set of 5 with controlled tempo.',
+      'Then complete 2 back-off sets at the same quality.',
+    ].join('\n');
+    const movementB = [
+      'B. Split Squat',
+      'Use full range and pause each rep in the bottom position.',
+      'Keep torso tall and control every eccentric.',
+    ].join('\n');
+    const movementC = [
+      'C. Hamstring Curl',
+      '3 x 12 with full contraction and slow eccentric.',
+      'Finish each set with 2-second peak squeeze.',
+    ].join('\n');
+
+    const workoutContent: WorkoutContent = {
+      overallNotes: '',
+      lowerBody: `### Lower Body:\n${movementA}\n\n${movementB}\n\n${movementC}`,
+      upperBody: '',
+    };
+
+    const chunks = buildGoogleSheetsCommentChunks(workoutContent, 180);
+    const lowerBodyChunks = chunks.filter(chunk => chunk.sectionName === 'Lower Body');
+
+    expect(lowerBodyChunks.length).toBe(3);
+    expect(lowerBodyChunks.every(chunk => chunk.charCount <= 180)).toBe(true);
+    expect(lowerBodyChunks.map(chunk => chunk.label)).toEqual([
+      'Lower Body (Part 1/3)',
+      'Lower Body (Part 2/3)',
+      'Lower Body (Part 3/3)',
+    ]);
+
+    const chunkWithA = lowerBodyChunks.find(chunk => chunk.content.includes('A. Back Squat'));
+    const chunkWithB = lowerBodyChunks.find(chunk => chunk.content.includes('B. Split Squat'));
+    const chunkWithC = lowerBodyChunks.find(chunk => chunk.content.includes('C. Hamstring Curl'));
+
+    expect(chunkWithA?.content.includes('Then complete 2 back-off sets at the same quality.')).toBe(true);
+    expect(chunkWithB?.content.includes('Keep torso tall and control every eccentric.')).toBe(true);
+    expect(chunkWithC?.content.includes('Finish each set with 2-second peak squeeze.')).toBe(true);
+  });
+
+  test('keeps chunk numbering and metadata consistent', () => {
+    const workoutContent: WorkoutContent = {
+      overallNotes: '### Overall Notes:\nGood pace today.',
+      lowerBody: '### Lower Body:\nA. Deadlift\n4 x 4',
+      upperBody: '### Upper Body:\nA. Press\n4 x 6',
+    };
+
+    const chunks = buildGoogleSheetsCommentChunks(workoutContent, 500);
+
+    expect(chunks.length).toBe(3);
+    expect(chunks[0]?.chunkNumber).toBe(1);
+    expect(chunks[1]?.chunkNumber).toBe(2);
+    expect(chunks[2]?.chunkNumber).toBe(3);
+    expect(chunks.every(chunk => chunk.chunkCount === 3)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds smart chunking to `./wgs post-workout --test` output for easy copy-paste into Google Sheets mobile app comments.

## Changes
- **New file:** `post-workout-comment-format.ts` — chunking logic
- **Updated:** `post-workout.ts` — uses new formatter for --test output
- **Tests:** 3 new tests covering section splits, movement splits, and metadata

## How it works
1. Chunks are limited to ~500 chars (safe for mobile paste)
2. Splits at Upper/Lower Body sections first
3. If a section is too long, splits by movement letter (A, B, C, D)
4. Never splits mid-movement or mid-sentence
5. Output includes clear `--- START COPY ---` / `--- END COPY ---` markers

## Example output
```
[Chunk 1/3] Lower Body (Part 1/2) (487 chars)
Paste into D3 comment.
--- START COPY ---
### Lower Body:
A. Back Squat...
--- END COPY ---
```