### PR TITLE
Print Notion URL after create-day

### DIFF
--- a/src/commands/create-day.ts
+++ b/src/commands/create-day.ts
@@ -129,5 +129,7 @@ export async function runCreateDay(options: CreateDayOptions): Promise<void> {
   console.log(`Creating Notion page: ${pageTitle}`);
 
   const pageId = await notionClient.createDayWorkoutPage(pageTitle, session);
+  const notionUrl = `https://notion.so/${pageId.replace(/-/g, '')}`;
   console.log(`✅ Successfully created Notion page: ${pageId}`);
+  console.log(`Notion URL: ${notionUrl}`);
 }


### PR DESCRIPTION
After creating a day workout page in Notion, prints a clickable Notion URL so it's easy to open directly from the CLI output.