### PR TITLE
Add get-workout CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Day mapping for `--day`:
 - `3` -> `D2`
 - `4` -> `E2`
 
+### Get Workout
+Get a workout page from Notion by date as markdown:
+```bash
+./wgs get-workout 2026-01-27
+./wgs get-workout 1/27/2026
+```
+
+The command looks for a nested Notion page with the normalized date title, such as `1/27/2026`, and prints standalone markdown to stdout.
+
 ### Post Workout
 Post workout notes from a Notion page back to Google Sheets as cell comments:
 ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "create-week": "bun run src/cli.ts create-week",
     "check-for-new-week": "bun run src/cli.ts check-for-new-week",
     "create-day": "bun run src/cli.ts create-day",
+    "get-workout": "bun run src/cli.ts get-workout",
     "post-workout": "bun run src/cli.ts post-workout"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,12 @@ import { CommandError, formatUnknownError } from './command-runtime';
 
 const program = new Command();
 
-function withCommandErrorHandling<TOptions>(
-  handler: (options: TOptions) => Promise<void>
-): (options: TOptions) => Promise<void> {
-  return async (options: TOptions): Promise<void> => {
+function withCommandErrorHandling<TArgs extends unknown[]>(
+  handler: (...args: TArgs) => Promise<void>
+): (...args: TArgs) => Promise<void> {
+  return async (...args: TArgs): Promise<void> => {
     try {
-      await handler(options);
+      await handler(...args);
     } catch (error) {
       if (error instanceof CommandError) {
         console.error(error.message);
@@ -66,6 +66,15 @@ program
   .action(withCommandErrorHandling(async (options) => {
     const { runCreateDay } = await import('./commands/create-day.js');
     await runCreateDay(options);
+  }));
+
+program
+  .command('get-workout')
+  .description('Get a Notion workout page by date as markdown')
+  .argument('<date>', 'Workout date (YYYY-MM-DD or M/D/YYYY)')
+  .action(withCommandErrorHandling(async (date: string) => {
+    const { runGetWorkout } = await import('./commands/get-workout.js');
+    await runGetWorkout(date);
   }));
 
 program

--- a/src/commands/create-day.ts
+++ b/src/commands/create-day.ts
@@ -1,6 +1,7 @@
 import { GoogleSheetsAuth } from '../auth';
 import { GoogleSheetsClient } from '../sheets';
 import { NotionClient } from '../notion';
+import { formatWorkoutDatePageTitleFromDate } from '../notion-workout-pages';
 import { WorkoutParser } from '../parser';
 import { fail } from '../command-runtime';
 import fs from 'fs/promises';
@@ -35,13 +36,6 @@ const DAY_TO_CELL: Record<number, string> = {
 async function loadConfig(): Promise<Config> {
   const configContent = await fs.readFile('config.json', 'utf8');
   return JSON.parse(configContent);
-}
-
-function formatDateM_D_YYYY(date: Date): string {
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const year = date.getFullYear();
-  return `${month}/${day}/${year}`;
 }
 
 export async function runCreateDay(options: CreateDayOptions): Promise<void> {
@@ -125,7 +119,7 @@ export async function runCreateDay(options: CreateDayOptions): Promise<void> {
   const notionClient = await NotionClient.fromConfigFile();
 
   const today = new Date();
-  const pageTitle = formatDateM_D_YYYY(today);
+  const pageTitle = formatWorkoutDatePageTitleFromDate(today);
   console.log(`Creating Notion page: ${pageTitle}`);
 
   const pageId = await notionClient.createDayWorkoutPage(pageTitle, session);

--- a/src/commands/get-workout.ts
+++ b/src/commands/get-workout.ts
@@ -1,0 +1,29 @@
+import { fail } from '../command-runtime';
+import {
+  formatWorkoutDatePageTitle,
+  loadWorkoutPagesConfig,
+  NotionWorkoutPageClient,
+} from '../notion-workout-pages';
+import { renderBlocksToText } from '../post-workout-rendering';
+import { R2ImageUploader } from '../r2';
+
+export async function runGetWorkout(dateInput: string): Promise<void> {
+  const pageTitle = formatWorkoutDatePageTitle(dateInput);
+  const config = await loadWorkoutPagesConfig();
+  const notionClient = new NotionWorkoutPageClient(config);
+  const pageId = await notionClient.findNestedPage(pageTitle);
+
+  if (!pageId) {
+    fail(`Notion page "${pageTitle}" not found in parent page`);
+  }
+
+  const blocks = await notionClient.extractPageContent(pageId);
+  const imageUploader = config.r2 ? new R2ImageUploader(config.r2) : undefined;
+  const renderedBlocks = await renderBlocksToText(blocks, {
+    pageId,
+    imageUploader,
+  });
+  const markdown = [`# ${pageTitle}`, renderedBlocks].filter(Boolean).join('\n\n');
+
+  console.log(markdown);
+}

--- a/src/commands/post-workout.ts
+++ b/src/commands/post-workout.ts
@@ -9,27 +9,14 @@ import {
   renderBlocksToText,
   splitContentByWorkoutSections,
 } from '../post-workout-rendering';
-import type { BlockWithDepth } from '../post-workout-rendering';
 import { R2ImageUploader } from '../r2';
-import type { R2Config } from '../r2';
-import fs from 'fs/promises';
-import { Client, isFullBlock } from '@notionhq/client';
-import type { BlockObjectResponse } from '@notionhq/client';
+import {
+  loadWorkoutPagesConfig,
+  NotionWorkoutPageClient,
+} from '../notion-workout-pages';
 import { OAuth2Client } from 'google-auth-library';
 import { google, sheets_v4 } from 'googleapis';
 import { spawn } from 'child_process';
-
-interface Config {
-  notion: {
-    token: string;
-    parentPageId: string;
-  };
-  r2?: R2Config;
-  defaults?: {
-    sheetOwner?: string;
-    sheetTitle?: string;
-  };
-}
 
 interface PostWorkoutOptions {
   sessionCell?: string;
@@ -65,11 +52,6 @@ type ResolvedPostWorkoutOptions =
     textMode: false;
     copyChunks: false;
   };
-
-async function loadConfig(): Promise<Config> {
-  const configContent = await fs.readFile('config.json', 'utf8');
-  return JSON.parse(configContent);
-}
 
 export function resolvePostWorkoutOptions(
   options: PostWorkoutOptions,
@@ -121,94 +103,6 @@ export function resolvePostWorkoutOptions(
     textMode: false,
     copyChunks: false,
   };
-}
-
-class PostWorkoutClient {
-  private notion: Client;
-  private parentPageId: string;
-
-  constructor(config: Config) {
-    this.notion = new Client({
-      auth: config.notion.token,
-    });
-    this.parentPageId = config.notion.parentPageId;
-  }
-
-  async findNestedPage(pageTitle: string): Promise<string | null> {
-    let hasMore = true;
-    let nextCursor: string | undefined;
-
-    while (hasMore) {
-      const response = await this.notion.blocks.children.list({
-        block_id: this.parentPageId,
-        page_size: 100,
-        start_cursor: nextCursor,
-      });
-
-      for (const block of response.results) {
-        if (!isFullBlock(block)) {
-          continue;
-        }
-
-        if (block.type === 'child_page' && block.child_page.title === pageTitle) {
-          return block.id;
-        }
-      }
-
-      hasMore = response.has_more;
-      nextCursor = response.next_cursor || undefined;
-    }
-
-    return null;
-  }
-
-  async extractPageContent(pageId: string): Promise<BlockWithDepth[]> {
-    return this.extractDescendants(pageId, 0);
-  }
-
-  private async listChildren(blockId: string): Promise<BlockObjectResponse[]> {
-    const children: BlockObjectResponse[] = [];
-    let hasMore = true;
-    let nextCursor: string | undefined;
-
-    while (hasMore) {
-      const response = await this.notion.blocks.children.list({
-        block_id: blockId,
-        page_size: 100,
-        start_cursor: nextCursor,
-      });
-
-      for (const block of response.results) {
-        if (isFullBlock(block)) {
-          children.push(block);
-        }
-      }
-
-      hasMore = response.has_more;
-      nextCursor = response.next_cursor || undefined;
-    }
-
-    return children;
-  }
-
-  private async extractDescendants(blockId: string, depth: number): Promise<BlockWithDepth[]> {
-    const descendants: BlockWithDepth[] = [];
-    const children = await this.listChildren(blockId);
-
-    for (const child of children) {
-      descendants.push({
-        ...child,
-        depth,
-      });
-
-      if (child.has_children) {
-        const childDescendants = await this.extractDescendants(child.id, depth + 1);
-        descendants.push(...childDescendants);
-      }
-    }
-
-    return descendants;
-  }
 }
 
 class ExtendedGoogleSheetsClient extends GoogleSheetsClient {
@@ -271,7 +165,7 @@ class ExtendedGoogleSheetsClient extends GoogleSheetsClient {
 }
 
 export async function runPostWorkout(options: PostWorkoutOptions): Promise<void> {
-  const config = await loadConfig();
+  const config = await loadWorkoutPagesConfig();
   const {
     sessionCell,
     notionPageTitle,
@@ -282,7 +176,7 @@ export async function runPostWorkout(options: PostWorkoutOptions): Promise<void>
   } = resolvePostWorkoutOptions(options, config.defaults);
 
   console.log('Connecting to Notion...');
-  const postWorkoutClient = new PostWorkoutClient(config);
+  const postWorkoutClient = new NotionWorkoutPageClient(config);
 
   console.log(`Searching for nested page: ${notionPageTitle}`);
   const pageId = await postWorkoutClient.findNestedPage(notionPageTitle);

--- a/src/notion-workout-pages.ts
+++ b/src/notion-workout-pages.ts
@@ -1,0 +1,173 @@
+import fs from 'fs/promises';
+import { Client, isFullBlock } from '@notionhq/client';
+import type { BlockObjectResponse } from '@notionhq/client';
+import type { R2Config } from './r2';
+import type { BlockWithDepth } from './post-workout-rendering';
+import { fail } from './command-runtime';
+
+export interface WorkoutPagesConfig {
+  notion: {
+    token: string;
+    parentPageId: string;
+  };
+  r2?: R2Config;
+  defaults?: {
+    sheetOwner?: string;
+    sheetTitle?: string;
+  };
+}
+
+export async function loadWorkoutPagesConfig(
+  configPath: string = 'config.json'
+): Promise<WorkoutPagesConfig> {
+  const configContent = await fs.readFile(configPath, 'utf8');
+  return JSON.parse(configContent);
+}
+
+export function formatWorkoutDatePageTitle(dateInput: string): string {
+  const trimmed = dateInput.trim();
+  const parsedDate = parseWorkoutDate(trimmed);
+
+  if (!parsedDate) {
+    fail(
+      `Invalid workout date "${dateInput}". Use YYYY-MM-DD or M/D/YYYY (for example, 2026-01-27 or 1/27/2026).`
+    );
+  }
+
+  return `${parsedDate.month}/${parsedDate.day}/${parsedDate.year}`;
+}
+
+export function formatWorkoutDatePageTitleFromDate(date: Date): string {
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+}
+
+export class NotionWorkoutPageClient {
+  private notion: Client;
+  private parentPageId: string;
+
+  constructor(config: WorkoutPagesConfig) {
+    this.notion = new Client({
+      auth: config.notion.token,
+    });
+    this.parentPageId = config.notion.parentPageId;
+  }
+
+  async findNestedPage(pageTitle: string): Promise<string | null> {
+    let hasMore = true;
+    let nextCursor: string | undefined;
+
+    while (hasMore) {
+      const response = await this.notion.blocks.children.list({
+        block_id: this.parentPageId,
+        page_size: 100,
+        start_cursor: nextCursor,
+      });
+
+      for (const block of response.results) {
+        if (!isFullBlock(block)) {
+          continue;
+        }
+
+        if (block.type === 'child_page' && block.child_page.title === pageTitle) {
+          return block.id;
+        }
+      }
+
+      hasMore = response.has_more;
+      nextCursor = response.next_cursor || undefined;
+    }
+
+    return null;
+  }
+
+  async extractPageContent(pageId: string): Promise<BlockWithDepth[]> {
+    return this.extractDescendants(pageId, 0);
+  }
+
+  private async listChildren(blockId: string): Promise<BlockObjectResponse[]> {
+    const children: BlockObjectResponse[] = [];
+    let hasMore = true;
+    let nextCursor: string | undefined;
+
+    while (hasMore) {
+      const response = await this.notion.blocks.children.list({
+        block_id: blockId,
+        page_size: 100,
+        start_cursor: nextCursor,
+      });
+
+      for (const block of response.results) {
+        if (isFullBlock(block)) {
+          children.push(block);
+        }
+      }
+
+      hasMore = response.has_more;
+      nextCursor = response.next_cursor || undefined;
+    }
+
+    return children;
+  }
+
+  private async extractDescendants(blockId: string, depth: number): Promise<BlockWithDepth[]> {
+    const descendants: BlockWithDepth[] = [];
+    const children = await this.listChildren(blockId);
+
+    for (const child of children) {
+      descendants.push({
+        ...child,
+        depth,
+      });
+
+      if (child.has_children) {
+        const childDescendants = await this.extractDescendants(child.id, depth + 1);
+        descendants.push(...childDescendants);
+      }
+    }
+
+    return descendants;
+  }
+}
+
+interface ParsedWorkoutDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+function parseWorkoutDate(dateInput: string): ParsedWorkoutDate | null {
+  const isoMatch = dateInput.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (isoMatch) {
+    return validatedDate({
+      year: Number(isoMatch[1]),
+      month: Number(isoMatch[2]),
+      day: Number(isoMatch[3]),
+    });
+  }
+
+  const slashMatch = dateInput.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/);
+  if (slashMatch) {
+    const rawYear = Number(slashMatch[3]);
+    return validatedDate({
+      year: rawYear < 100 ? 2000 + rawYear : rawYear,
+      month: Number(slashMatch[1]),
+      day: Number(slashMatch[2]),
+    });
+  }
+
+  return null;
+}
+
+function validatedDate(date: ParsedWorkoutDate): ParsedWorkoutDate | null {
+  const candidate = new Date(date.year, date.month - 1, date.day);
+
+  if (
+    candidate.getFullYear() !== date.year
+    || candidate.getMonth() !== date.month - 1
+    || candidate.getDate() !== date.day
+  ) {
+    return null;
+  }
+
+  return date;
+}

--- a/test/get-workout-options.test.ts
+++ b/test/get-workout-options.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { CommandError } from '../src/command-runtime';
+import {
+  formatWorkoutDatePageTitle,
+  formatWorkoutDatePageTitleFromDate,
+} from '../src/notion-workout-pages';
+
+describe('formatWorkoutDatePageTitle', () => {
+  test('normalizes ISO dates to Notion page titles', () => {
+    expect(formatWorkoutDatePageTitle('2026-01-27')).toBe('1/27/2026');
+  });
+
+  test('normalizes slash dates with leading zeros', () => {
+    expect(formatWorkoutDatePageTitle('01/07/2026')).toBe('1/7/2026');
+  });
+
+  test('normalizes two-digit slash years', () => {
+    expect(formatWorkoutDatePageTitle('1/27/26')).toBe('1/27/2026');
+  });
+
+  test('rejects invalid dates', () => {
+    expect(() => formatWorkoutDatePageTitle('2026-02-31')).toThrow(CommandError);
+  });
+
+  test('formats Date objects with the same page title convention', () => {
+    expect(formatWorkoutDatePageTitleFromDate(new Date(2026, 0, 27))).toBe('1/27/2026');
+  });
+});


### PR DESCRIPTION
## Summary
- add get-workout <date> to render a Notion workout page as markdown
- factor shared Notion workout page lookup/extraction
- align create-day with the shared date-title formatter

## Tests
- bun test
- bunx tsc --noEmit
- bun run src/cli.ts --help
- bun run src/cli.ts get-workout not-a-date